### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ one can set the [`syncInterval`](./cluster/config.go) value to a low value. The 
   - `Put`: create key/value pair that is eventually distributed in the cluster of nodes. The `key` is a string and the `value` is a byte array. One can set an expiry to the key.
   - `PutProto`: to create a key/value pair where the value is a protocol buffer message
   - `PutString`: to create a key/value pair where the value is a string
-  - `PutAny`: to create a key/value pair with a given [`Codec`](./cluster/codec.go) to encode the value type.
+  - `PutAny`: to create a key/value pair with a given [`Codec`](./codec.go) to encode the value type.
   - `Get`: retrieves the value of a given `key` from the cluster of nodes. This can return a false negative meaning that the key may exist but at the time of checking it is having yet to be replicated in the cluster.
   - `GetProto`: retrieves a protocol buffer message for a given `key`. This requires `PutProto` or `Put` to be used to set the value.
   - `GetString`: retrieves a string value for a given `key`. This requires `PutString` or `Put` to be used to set the value.


### PR DESCRIPTION
# Summary

`/cluster/` dir is no longer exists. `codec.go` file is now located in root path